### PR TITLE
[#176][#266][#269] Vivian Rocky Linux and IRIS update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2012-2013 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.14)
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 project(VISTA NONE)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake ${CMAKE_MODULE_PATH})

--- a/Documentation/generateDockerViViaNAndDox.rst
+++ b/Documentation/generateDockerViViaNAndDox.rst
@@ -10,14 +10,13 @@ pages utilizing a set of OSEHRA developed Docker scripts.  These scripts are
 provided to minimize the set up work necessary and automate the generation of a
 copy of ViViaN and the DOX pages.
 
-For instructions on the manual process needed for a non-Cache system, see
-`Generate ViViaN and DOX`_.
+See `Generate ViViaN and DOX`_ for detailed steps.
 
 The scripts will
 
-* Provision a CentOS Virtual Machine (VM)
-* Install Intersystems Cache from supplied installer
-* Export the VistA code from a given CACHE.DAT file
+* Provision a Rocky Linux container
+* Install Intersystems IRIS from supplied installer
+* Export the VistA code from a given IRIS.DAT file
 * Execute the tasks to generate the ViViaN and DOX pages
 * Install Apache web server
 * Clone ViViaN repository and set up data for viewing
@@ -44,13 +43,13 @@ The scripts expect three files to be supplied in order to set up the environment
 +--------------------------------+---------------------------------------------------------------+
 |    Input file                  |                        Description                            |
 +--------------------------------+---------------------------------------------------------------+
-|         CACHE.DAT              | A .dat file which contains the VistA instance to display      |
+|         IRIS.DAT               | A .dat file which contains the VistA instance to display      |
 +--------------------------------+---------------------------------------------------------------+
-|         CACHE.key              | A license file for the Cache instance                         |
+|         IRIS.key (optional)    | A license file for the IRIS instance                         |
 +--------------------------------+---------------------------------------------------------------+
-| cache-<version>lnxrhx64.tar.gz | A Cache install zip file for RedHat Linux                     |
-|                                | **Must contain a cinstall_silent file to be executed,**       |
-|                                | (Tested using the 2014.1.3 & 2016.1.0 version)                |
+| IRIS-<version>lnxrh8x64.tar.gz | An IRIS install zip file for RedHat Linux                     |
+|                                | **Must contain a irisinstall_silent file to be executed,**    |
+|                                | (Tested using the 2023.3.0.254.0 version)                     |
 +--------------------------------+---------------------------------------------------------------+
 
 
@@ -64,11 +63,11 @@ following settings:
 +-----------------+--------------------------------------------------------+
 |  Setting        |   Value                                                |
 +-----------------+--------------------------------------------------------+
-|  CPUs           |    4                                                   |
+|  CPUs           |    9                                                   |
 +-----------------+--------------------------------------------------------+
-|  Memory         |    3072MB                                              |
+|  Memory         |    9000MB                                              |
 +-----------------+--------------------------------------------------------+
-| Disk Image size |    96GB                                                |
+| Disk Image size |    200GB                                               |
 +-----------------+--------------------------------------------------------+
 
 For information on how to set these parameters, see the following URL:
@@ -87,14 +86,14 @@ OSEHRA Source Repository
 +-----------------+--------------------------------------------------------+
 |   Code Bases    |   Web Link                                             |
 +-----------------+--------------------------------------------------------+
-|  docker-vista   |    https://github.com/OSEHRA/docker-vista              |
+|  docker-vista   |    https://github.com/WorldVistA/docker-vista          |
 +-----------------+--------------------------------------------------------+
 
 Use Git to make a local clone of the docker-vista repository.
 
 .. parsed-literal::
 
-  $ git clone https://github.com/OSEHRA/docker-vista.git
+  $ git clone https://github.com/WorldVistA/docker-vista.git
   Cloning into 'docker-vista'...
   .
   .
@@ -104,16 +103,15 @@ Place Source files
 ------------------
 
 Now that the repository has been cloned, copy the three Cache source files from
-the above table into the ``docker-vista/cache-files`` directory.
+the above table into the ``docker-vista/iris-files`` directory.
 
-The testing instances used had the following ``cache-files`` directory:
+The testing instances used had the following ``iris-files`` directory:
 
 .. parsed-literal::
 
-  $ ls cache-files
-    CACHE.DAT
-    cache.key
-    cache-2016.1.0.656.0lnxrhx64.tar.gz
+  $ ls iris-files
+    IRIS.DAT
+    IRIS_Community-2023.3.0.254.0-lnxrh8x64.tar.gz
 
 Execute Docker Build
 --------------------
@@ -128,12 +126,11 @@ referenced when starting the image in a container.
 
 .. parsed-literal::
 
-  docker build --build-arg flags="-c -b -v" --build-arg postInstallScript="-p ./Common/pvPostInstall.sh" -t vivian .
+  docker build --progress=plain --no-cache --build-arg flags="-c -b -v -p ./Common/vivianPostInstall.sh" --build-arg entry="/opt/irissys" --build-arg instance="foia" -t irisviv .
 
 Docker will then execute the commands in the DockerFile, culminating in a
 Docker image which has all of the necessary programs and files to view the
 ViViaN and DOX pages via a web browser.
-
 
 The script will describe each step as the Docker process runs and will print a
 large amount of information to the terminal window. A snippet of the run looks
@@ -142,7 +139,7 @@ as below:
 .. parsed-literal::
 
   Sending build context to Docker daemon  4.064GB
-  Step 1/23 : FROM centos
+  Step 1/23 : FROM rockylinux:8.9
    ---> 2d194b392dd1
   Step 2/23 : RUN echo "multilib_policy=best" >> /etc/yum.conf
    ---> Using cache
@@ -192,7 +189,6 @@ the host machine to ports on the running container. This is done to allow:
 * SSH access to the Docker container
 * viewing of the Cache Management Portal
 * access the web server that is on the container.
-* allow VistA GUI connections to the running instance
 
 The final argument given to the command is the tag of the image built in the
 previous step. If you changed the tag there, ensure that it is changed here a
@@ -201,7 +197,7 @@ well.
 
 .. parsed-literal::
 
-  docker run -p 9430:9430 -p 8001:8001 -p 2222:22 -p 8080:8080 -p 57772:57772 -p 3080:80 -d --name=vivianvista vivian
+  docker run -p 2222:22 -p 57772:57772 -p 3080:80 -d --name=vivianvista vivian
 
 An explanation of the arguments to the command is broken down here:
 
@@ -226,7 +222,7 @@ The initial return of the command is simply the ID of the started container.
 
 .. parsed-literal::
 
-  $ docker run -p 9430:9430 -p 8001:8001 -p 2222:22 -p 8080:8080 -p 57772:57772 -p 3080:80 -d --name=vivianvista viviandocker ps
+  $ docker run -p 2222:22 -p 57772:57772 -p 3080:80 -d --name=vivianvista viviandocker
     d8b6e1b46aa7
 
 The Docker container can be verified as running by executing the ``docker ps``
@@ -259,3 +255,29 @@ or the DOX pages:
    http://localhost:3080/dox/
 
 .. _`Generate ViViaN and DOX`: ./generateViViaNAndDox.rst
+
+Deploying Vivian on a Public Server from the Docker Container
+*************************************************************
+Go inside the container and tar the server root:
+
+.. parsed-literal::
+
+   docker exec -it vivianvista bash
+   cd /var/www/html/
+   tar -czvf /vivian-April2023.tgz ./*
+
+Copy them out from the docker container on your Linux machine:
+
+.. parsed-literal::
+
+   docker cp cache:/var/www/html/vivian-April2023.tgz /home/nancy
+
+Move the ``tgz`` to the destination public server, and unzip at the website root, e.g.
+(assuming the website root is ``/var/www/html/vivian/``):
+
+.. parsed-literal::
+
+   mkdir /var/www/html/vivian; tar xzvf vivian-April2023.tgz -C /var/www/html/vivian/
+
+Vivian does not come with an ``index.html`` page. You have to either supply your own or
+symlink an ``index.php`` to ``vivian/index.php``.

--- a/Documentation/generateViViaNAndDox.rst
+++ b/Documentation/generateViViaNAndDox.rst
@@ -25,7 +25,7 @@ Automated Generation
 ********************
 
 
-**Cache Systems Only**
+**IRIS Systems Only**
 
 OSEHRA has generated a  set of scripts to be run by Docker to automatically
 generate the ViViaN and DOX pages.  To see the documentation and setup required
@@ -39,9 +39,9 @@ Install and Setup Required Components
 Machine requirements
 ********************
 
-* OS: Windows with Cache or Linux with GT.M or Cache
+* OS: Windows with IRIS or Linux with GT.M or IRIS
 * CPU: At least Pentium 1.5GHZ
-* Hard drive: at least 35GB free disk space
+* Hard drive: at least 100GB free disk space
   (Note: The VistA-M repository is ~20GB and the generated files are ~8GB)
 * Memory: at least 2GB
 
@@ -52,9 +52,9 @@ Required Tools
 +-----------------------------+---------------------------------------------------------------+
 |    Tools                    |                        Web Link                               |
 +-----------------------------+---------------------------------------------------------------+
-|   CMake (2.8+)              | www.cmake.org                                                 |
+|   CMake (3.14)              | www.cmake.org                                                 |
 +-----------------------------+---------------------------------------------------------------+
-| Python 2.7 or 3 (preferred) | www.python.org                                                |
+| Python 3.12                 | www.python.org                                                |
 +-----------------------------+---------------------------------------------------------------+
 |       Git                   | www.git-scm.com                                               |
 +-----------------------------+---------------------------------------------------------------+
@@ -83,18 +83,16 @@ Download the latest FOIA released ICR_.
 ViViAN Repository
 *****************
 
-Use Git to clone the Product-Management or ViViAN repository.
+Use Git to clone the ViViAN repository.
 
 .. parsed-literal::
 
-  $ git clone https://github.com/OSEHRA-Sandbox/Product-Management
-  Cloning into 'Product-Management'...
+  $ git clone https://github.com/WorldVistA/ViViaN.git vivian
+  Cloning into 'vivian'...
   .
   .
   .
 
-Create a symbolic link from ``Product-Management/Visual`` to the ``vivian``
-directory, e.g. ``C:\wamp64\www\vivian``.
 
 VistA Repository
 ****************
@@ -103,7 +101,7 @@ Clone of the OSEHRA VistA repository.
 
 .. parsed-literal::
 
-  $ git clone https://github.com/OSEHRA/VistA
+  $ git clone https://github.com/WorldVistA/VistA
   Cloning into 'VistA'...
   .
   .
@@ -120,15 +118,15 @@ ObtainingVistAMCode_ to obtain the source code. Next, follow the instructions
 below based upon which type of MUMPS database will be utilized for the VistA
 installation:
 
-Caché
+IRIS
 ~~~~~
 If necessary, OSEHRA has compiled a set of instructions on how to install the
-Caché instance: InstallCache_.
+IRIS instance: InstallCache_.
 
-To import the MUMPS code from the OSEHRA VistA-M Repository into a Caché
+To import the MUMPS code from the OSEHRA VistA-M Repository into a IRIS
 instance, see `Automated VistA Configuration`_.
 
-Instructions for additional configuration of the Caché environment can be
+Instructions for additional configuration of the IRIS environment can be
 found here: ConfigureCache_.
 
 GT.M
@@ -164,7 +162,7 @@ at the top of the window so that the source code points to the VistA
 repository. The binaries path can be set to any directory, preferably one
 outside of the VistA repository tree.
 
-.. figure:: http://code.osehra.org/content/named/SHA1/f4a9de-launchCmakeGUI.png
+.. figure:: http://code.worldvista.org/content/named/SHA1/f4a9de-launchCmakeGUI.png
    :align: center
    :alt:  Initial CMake-GUI page
 
@@ -174,21 +172,21 @@ default option (Borland Makefile on a Windows environment and Unix Makefiles on
 a Linux system) is suffcient. Click \"Finish\" after the selection is made to
 continue the configuration process.
 
-.. figure:: http://code.osehra.org/content/named/SHA1/D76CF0-selectGenerator.png
+.. figure:: http://code.worldvista.org/content/named/SHA1/D76CF0-selectGenerator.png
    :align: center
    :alt:  Generator selection
 
 Following generator selection, the interface will produce a highlighted display
 with three options:
 
-.. figure:: http://code.osehra.org/content/named/SHA1/1086c5-initialCMakeGUI.png
+.. figure:: http://code.worldvista.org/content/named/SHA1/1086c5-initialCMakeGUI.png
    :align: center
    :alt:  Result of first CMake configuration
 
 Select `DOCUMENT_VISTA` and click the \"Configure\" button again. The CMake-GUI
 will be updated new entries and an error message:
 
-.. figure:: http://code.osehra.org/content/named/SHA1/835c6c-configureCMakeGUI.png
+.. figure:: http://code.worldvista.org/content/named/SHA1/835c6c-configureCMakeGUI.png
    :align: center
    :alt:  Result of CMake configuration after DOCUMENT_VISTA is selected
 
@@ -204,7 +202,7 @@ package and are available to download from a link on the DOX Package pages.
 This option increases the generation time significantly, and, therefore is not
 selected by default.
 
-The following variables are required for both Cache and GT.M environments.
+The following variables are required for both IRIS and GT.M environments.
 
 +---------------------------+---------------------------------------------------------------+
 | Variable Name             |       Description                                             |
@@ -226,13 +224,13 @@ The following variables are required for both Cache and GT.M environments.
 PYTHON_EXECUTABLE during configuration, to see or update the default values,
 click on the \"Advanced\" toggle in the CMake-GUI.
 
-These variables are Cache- or GT.M- specific and will pre-populated with
+These variables are IRIS- or GT.M- specific and will pre-populated with
 default values.
 
 +------------------------+------------------------------------+------------------------------------+
-|   Variable Name        |     Value for Testing in Caché     |     Value for Testing in GT.M      |
+|   Variable Name        |     Value for Testing in IRIS     |     Value for Testing in GT.M      |
 +------------------------+------------------------------------+------------------------------------+
-| CCONTROL_EXECUTABLE    |      Path to CControl Executable   |                    N/A             |
+| CCONTROL_EXECUTABLE    |      Path to ``iris`` Executable   |                    N/A             |
 | (Advanced)             |                                    |                                    |
 +------------------------+------------------------------------+------------------------------------+
 | CTERM_EXECUTABLE       |      Path to CTerm Executable      |                    N/A             |
@@ -240,12 +238,12 @@ default values.
 +------------------------+------------------------------------+------------------------------------+
 | VISTA_CACHE_NAMESPACE  |      Namespace of VistA routines   |                    N/A             |
 +------------------------+------------------------------------+------------------------------------+
-| VISTA_CACHE_INSTANCE   |      Caché Instance Name           |                    N/A             |
+| VISTA_CACHE_INSTANCE   |      IRIS Instance Name            |                    N/A             |
 +------------------------+------------------------------------+------------------------------------+
-| VISTA_CACHE_USERNAME   |      Login Username for Caché      |                    N/A             |
+| VISTA_CACHE_USERNAME   |      Login Username for IRIS       |                    N/A             |
 |                        |      (if necessary)                |                                    |
 +------------------------+------------------------------------+------------------------------------+
-| VISTA_CACHE_PASSWORD   | Login Password for Caché           |                    N/A             |
+| VISTA_CACHE_PASSWORD   | Login Password for IRIS            |                    N/A             |
 |                        | (if necessary)                     |                                    |
 +------------------------+------------------------------------+------------------------------------+
 | GTM_DIST               |               N/A                  |     Path to GTM distribution Dir   |
@@ -256,7 +254,7 @@ default values.
 
 Once the options are set, press \"Configure\" again and then \"Generate\".
 
-.. figure:: http://code.osehra.org/content/named/SHA1/6ce087-generateCMakeGUI.png
+.. figure:: http://code.worldvista.org/content/named/SHA1/6ce087-generateCMakeGUI.png
    :align: center
    :alt:  Result of CMake generate
 
@@ -443,7 +441,7 @@ ViViaN Setup Script
 *******************
 
 Finally, execute the setup script from the ViViaN scripts
-(``Product-Management/Visual/scripts``) directory: ``python setup.py`` to
+(``vivian/scripts``) directory: ``python setup.py`` to
 generate other JSON and csv files.
 
 The setup script has two optional arguments, ``files_dir`` and ``dox_dir``.
@@ -482,6 +480,6 @@ file from your favorite web browser.
 .. _InstallCache: InstallCache.rst
 .. _ConfigureCache: ConfigureCache.rst
 .. _`Automated VistA Configuration`: AutomatedVistAConfiguration.rst
-.. _`M Routine Analyzer`: https://github.com/jasonli2000/rgivistatools/tree/fileman_json
+.. _`M Routine Analyzer`: https://github.com/WorldVistA/rgivistatools/tree/fileman_json
 .. _`google_code_prettify`: https://github.com/google/code-prettify
 .. _xlrd: https://pypi.python.org/pypi/xlrd

--- a/Python/vista/OSEHRAHelper.py
+++ b/Python/vista/OSEHRAHelper.py
@@ -1,6 +1,7 @@
 #---------------------------------------------------------------------------
 # Copyright 2012 The Open Source Electronic Health Record Agent
 # Copyright 2017 Sam Habiel. writectrl methods.
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -130,14 +131,14 @@ class ConnectMUMPS(object):
   def getenv(self, volume):
     self.write('D GETENV^%ZOSV W Y')
     if sys.platform == 'win32':
-      match = self.wait_re(volume + ':.+\s', None)
+      match = self.wait_re(volume + r':.+\s', None)
       test = match[1].span()
       VistAboxvol = ''
       for i in range(test[0], test[1]):
         VistAboxvol = VistAboxvol + decode(match[2])[i]
       self.boxvol = VistAboxvol.strip()
     else:
-      self.wait_re(volume + ':.+\s', None)
+      self.wait_re(volume + r':.+\s', None)
       self.boxvol = self.connection.after.strip()
 
   def IEN(self, file, objectname):
@@ -305,7 +306,7 @@ class ConnectWinCache(ConnectMUMPS):
 class ConnectLinuxCache(ConnectMUMPS):
   def __init__(self, logfile, instance, namespace, location='127.0.0.1'):
     super(ConnectMUMPS, self).__init__()
-    self.connection = pexpect.spawn('ccontrol session ' + instance + ' -U ' + namespace, timeout=None, encoding='utf-8', codec_errors='ignore')
+    self.connection = pexpect.spawn('irissession ' + instance + ' -U ' + namespace, timeout=None, encoding='utf-8', codec_errors='ignore')
     if len(namespace) == 0:
       namespace = 'VISTA'
     self.namespace = namespace
@@ -686,10 +687,10 @@ class ConnectRemoteSSH(ConnectMUMPS):
 
   """
   Added to convert regex's into regular string matching. It replaces special
-  characters such as '?' into '\?'
+  characters such as '?' into '\\?'
   """
   def escapeSpecialChars(self, string):
-    re_chars = '?*.+-|^$\()[]{}'
+    re_chars = r'?*.+-|^$\()[]{}'
     escaped_str = ''
     for c in string:
         if c in re_chars:
@@ -697,7 +698,7 @@ class ConnectRemoteSSH(ConnectMUMPS):
         escaped_str += c
     return escaped_str
 
-def ConnectToMUMPS(logfile, instance='CACHE', namespace='VISTA',
+def ConnectToMUMPS(logfile, instance='IRIS', namespace='VISTA',
                    location='127.0.0.1', remote_conn_details=None):
     # self.namespace = namespace
     # self.location = location

--- a/Scripts/DefaultKIDSBuildInstaller.py
+++ b/Scripts/DefaultKIDSBuildInstaller.py
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
-# Copyright 2024 Sam Habiel
+# Copyright 2024 Sam Habiel: Backup, Python3.12 changes
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,16 +60,16 @@ class DefaultKIDSBuildInstaller(object):
     it is a general question
   """
   KIDS_MENU_OPTION_ACTION_LIST = [
-      ("Want to continue installing this build\?","YES", False),
+      (r"Want to continue installing this build\?","YES", False),
       ("Enter the Coordinator for Mail Group", "POSTMASTER", False),
-      ("Want KIDS to Rebuild Menu Trees Upon Completion of Install\?",
+      (r"Want KIDS to Rebuild Menu Trees Upon Completion of Install\?",
        "", False),
       ("Want KIDS to INHIBIT LOGONs during the install?",
        "NO", False),
-      ("Want to DISABLE Scheduled Options, Menu Options, and Protocols\?",
+      (r"Want to DISABLE Scheduled Options, Menu Options, and Protocols\?",
        "NO", False),
-      ("Delay Install \(Minutes\):  \(0\-60\):", "0", False),
-      ("do you want to include disabled components\?", "NO", False),
+      (r"Delay Install \(Minutes\):  \(0\-60\):", "0", False),
+      (r"do you want to include disabled components\?", "NO", False),
       ("DEVICE:", '0;P-OTHER;80;999999999', True)
   ]
 
@@ -85,10 +85,10 @@ class DefaultKIDSBuildInstaller(object):
   """
   KIDS_LOAD_QUESTION_ACTION_LIST = [
       ("OK to continue with Load","YES", False),
-      ("Want to Continue with Load\?","YES", False),
+      (r"Want to Continue with Load\?","YES", False),
       ("Select Installation ","?", True),
-      ("Want to continue installing this build\?","YES", False),
-      ("Want to RUN the Environment Check Routine\? YES//","YES",False)
+      (r"Want to continue installing this build\?","YES", False),
+      (r"Want to RUN the Environment Check Routine\? YES//","YES",False)
   ]
 
   """ option action list for Exit KIDS menu, similar struct as above """
@@ -97,7 +97,7 @@ class DefaultKIDSBuildInstaller(object):
       ("Select Kernel Installation & Distribution System ", "", False),
       ("Select Programmer Options ", "", False),
       ("Select Systems Manager Menu ", "", False),
-      ("Do you really want to halt\?", "YES", True)
+      (r"Do you really want to halt\?", "YES", True)
   ]
 
   KIDS_FILE_PATH_MAX_LEN = 75 # this might need to be fixed in VistA XPD
@@ -240,7 +240,7 @@ class DefaultKIDSBuildInstaller(object):
   """ restart the previous installation
   """
   def restartInstallation(self, vistATestClient):
-    logger.warn("restart the previous installation for %s" %
+    logger.warning("restart the previous installation for %s" %
                 self._kidsInstallName)
     connection = vistATestClient.getConnection()
     self.__gotoKIDSMainMenu__(vistATestClient)
@@ -286,7 +286,7 @@ class DefaultKIDSBuildInstaller(object):
       self.__gotoKIDSMainMenu__(vistATestClient)
     self.__selectUnloadDistributionOption__(connection)
     index = connection.expect([
-      "Want to continue with the Unload of this Distribution\? NO// ",
+      r"Want to continue with the Unload of this Distribution\? NO// ",
       "Select INSTALL NAME: "])
     if index == 1:
       connection.send('\r')
@@ -425,7 +425,7 @@ class DefaultKIDSBuildInstaller(object):
     installStatus = infoFetcher.getInstallationStatus(self._kidsInstallName)
     """ select KIDS installation workflow based on install status """
     if infoFetcher.isInstallCompleted(installStatus):
-      logger.warn("install %s is already completed!" %
+      logger.warning("install %s is already completed!" %
                    self._kidsInstallName)
       if not reinst:
         return True
@@ -537,7 +537,7 @@ class DefaultKIDSBuildInstaller(object):
   def handleKIDSInstallQuestions(self, connection, **kargs):
     errorCheckTimeout = 5 # 5 seconds
     try:
-      connection.expect("\*\*INSTALL FILE IS CORRUPTED\*\*",errorCheckTimeout)
+      connection.expect(r"\*\*INSTALL FILE IS CORRUPTED\*\*",errorCheckTimeout)
       logger.error("%s:INSTALL FILE IS CORRUPTED" % self._kidsInstallName)
       connection.expect("Select Installation ", errorCheckTimeout)
       connection.send('\r')
@@ -559,7 +559,7 @@ class DefaultKIDSBuildInstaller(object):
   def extraFixWork(self, vistATestClient):
     # use KIDS entry point to manually create package link for install
     if self._updatePackageLink:
-      logger.warn("Attempting to manually creating the package link for: %s" %
+      logger.warning("Attempting to manually creating the package link for: %s" %
             (self._kidsInstallName))
       connection = vistATestClient.getConnection()
       # Luckily, the command just takes the patch information in order, ie "SD", "5.3", "701"
@@ -655,7 +655,7 @@ def getPersonNameByDuz(inputDuz, vistAClient):
   menuUtil.exitSystemMenu(vistAClient)
   vistAClient.waitForPrompt()
   connection.send('W $$NAME^XUSER(%s)\r' % inputDuz)
-  connection.expect('\)') # get rid of the echo
+  connection.expect(r'\)') # get rid of the echo
   vistAClient.waitForPrompt()
   result = connection.lastconnection.strip(' \r\n')
   connection.send('\r')
@@ -686,7 +686,7 @@ def addPackagePatchHistory(packageName, version, seqNo,
   connection.send("\r")
   connection.expect("Select PATCH APPLICATION HISTORY: ")
   connection.send("%s SEQ #%s\r" % (patchNo, seqNo))
-  connection.expect("Are you adding .*\? No//")
+  connection.expect(r"Are you adding .*\? No//")
   connection.send("YES\r")
   connection.expect("DATE APPLIED: ")
   connection.send("T\r")

--- a/Scripts/GitUtils.py
+++ b/Scripts/GitUtils.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2013-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel: Python 3.12 support
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -120,19 +121,19 @@ def addChangeSet(gitRepoDir=None, patternList=[]):
                   diffStack.append(s[2:])
                 if s[0] == "+":
                   if len(diffStack):
-                    if re.search("DIC\(9.8,",s[2:]):
+                    if re.search(r"DIC\(9.8,",s[2:]):
                       break
-                    if re.search("[0-9]{7}(\.[0-9]{4,6})*",s[2:]) or re.search("[0-9]{7}(\.[0-9]{4,6})*",diffStack[0]):
+                    if re.search(r"[0-9]{7}(\.[0-9]{4,6})*",s[2:]) or re.search(r"[0-9]{7}(\.[0-9]{4,6})*",diffStack[0]):
                       results.append("DATE")
                       break
-                    if re.search("[0-9]{2}\-[A-Z]{3}\-[0-9]{4}",s[2:]) or re.search("[0-9]{2}\:[0-9]{2}\:[0-9]{2}",diffStack[0]) :
+                    if re.search(r"[0-9]{2}\-[A-Z]{3}\-[0-9]{4}",s[2:]) or re.search(r"[0-9]{2}\:[0-9]{2}\:[0-9]{2}",diffStack[0]) :
                       results.append("DATE")
                       break
-                    if re.search("[0-9]{2}:[0-9]{2}:[0-9]{2}",s[2:]) or re.search("[0-9]{2}\:[0-9]{2}\:[0-9]{2}",diffStack[0]) :
+                    if re.search(r"[0-9]{2}:[0-9]{2}:[0-9]{2}",s[2:]) or re.search(r"[0-9]{2}\:[0-9]{2}\:[0-9]{2}",diffStack[0]) :
                       results.append("DATE")
                       break
                     # Removes a specific global entry in DEVICE file which maintains a count of the times the device was opened
-                    if re.search("%ZIS\([0-9]+,[0-9]+,5",s[2:]):
+                    if re.search(r"%ZIS\([0-9]+,[0-9]+,5",s[2:]):
                       break
                     diffStack.pop(0)
             outLineStack.pop(0)

--- a/Scripts/IntersysCacheUtils.py
+++ b/Scripts/IntersysCacheUtils.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2013-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -213,7 +214,7 @@ def backupCacheDataByGitHash(instanceName, origDataPath, backupDir,
     logger.info("Creating tar file for %s" % origDataPath)
     createBZIP2Tarball(origDataPath, destFile)
   else:
-    logger.warn("%s already exists" % destFile)
+    logger.warning("%s already exists" % destFile)
   return True
 
 """

--- a/Scripts/KIDSBuildParser.py
+++ b/Scripts/KIDSBuildParser.py
@@ -4,7 +4,7 @@
 #
 #---------------------------------------------------------------------------
 # Copyright 2011-2019 The Open Source Electronic Health Record Alliance
-# Copyright 2024 Sam Habiel
+# Copyright 2024 Sam Habiel: Backup, Python3.12 changes
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -84,8 +84,8 @@ class DebugSectionParser(ISectionParser):
   @inherits ISectionParser
 """
 class RoutineSectionParser(ISectionParser):
-  ROUTINE_START = re.compile("^\"RTN\"\)")
-  NEW_ROUTINE_START = re.compile("^\"RTN\",\"(?P<Name>[^,\"]+)\"\)$")
+  ROUTINE_START = re.compile(r"^\"RTN\"\)")
+  NEW_ROUTINE_START = re.compile(r"^\"RTN\",\"(?P<Name>[^,\"]+)\"\)$")
   """
   """
   def __init__(self, outputDir, **kargs):
@@ -251,12 +251,12 @@ class BuildSectionParser(ISectionParser):
   def __initHandler__(self):
     """ based on BUILD file schema """
     self._handlers = (
-      (re.compile(',"INI"\)$'), self.__handlePreInstallRoutine__),
-      (re.compile(',"INIT"\)$'), self.__handlePostInstallRoutine__),
-      (re.compile(',"PRE"\)$'), self.__handleEnvCheckRoutine__),
-      (re.compile(',6\)$'), self.__handleSeqNo__),
-      (re.compile(',"INID"\)$'), self.__handleRoutineCleanup__),
-      (re.compile(',"REQB",[0-9]+,0\)$'), self.__handleReqiredBuild__),
+      (re.compile(r',"INI"\)$'), self.__handlePreInstallRoutine__),
+      (re.compile(r',"INIT"\)$'), self.__handlePostInstallRoutine__),
+      (re.compile(r',"PRE"\)$'), self.__handleEnvCheckRoutine__),
+      (re.compile(r',6\)$'), self.__handleSeqNo__),
+      (re.compile(r',"INID"\)$'), self.__handleRoutineCleanup__),
+      (re.compile(r',"REQB",[0-9]+,0\)$'), self.__handleReqiredBuild__),
     )
   def __handlePreInstallRoutine__(self, lines, kidsBuild):
     line2 = lines[1]
@@ -301,7 +301,7 @@ class BuildSectionParser(ISectionParser):
     if len(fields) > 0:
       kidsBuild.addDependencyBuild(fields)
     else:
-      logger.warn("no require build information for [%s]" % lines)
+      logger.warning("no require build information for [%s]" % lines)
 
 """
   object to store information related to a KIDS build
@@ -441,39 +441,39 @@ class KIDSBuildParser(ISectionParser):
   """
     regular expression to determine the start of the section
   """
-  BUILD_START = re.compile("^\"BLD\",[0-9]+,0\)$")
-  VER_START = re.compile("^\"VER\"\)")
+  BUILD_START = re.compile(r"^\"BLD\",[0-9]+,0\)$")
+  VER_START = re.compile(r"^\"VER\"\)")
   """
     regular expression to determine which section that current line belongs to
   """
-  KIDS_LINE = re.compile("^\*\*KIDS\*\*")
-  INSTALL_NAME_LINE = re.compile("^\*\*INSTALL NAME\*\*$")
-  DATA_LINE = re.compile("^\"DATA\"")
-  DATA_DICTIONARY_LINE = re.compile("^\"\^DD\",")
-  SEC_LINE = re.compile("^\"SEC\",")
-  UP_LINE = re.compile("^\"UP\",")
-  QUES_LINE = re.compile("^\"QUES\",\".*\",.*\)$")
-  TEMP_LINE = re.compile("^\"TEMP\",")
-  MBREQ_LINE = re.compile("\"MBREQ\"")
-  ORD_LINE = re.compile("^\"ORD\",") # option, RPC, templates etc
-  ROUTINE_LINE = re.compile("^\"RTN\"")
-  BUILD_LINE = re.compile("^\"BLD\",[0-9]+")
-  VERSION_LINE = re.compile("^\"VER\"\)$")
-  PRE_INSTALL_ROUTINE_LINE = re.compile("^\"INI\"\)$")
-  POST_INSTALL_ROUTINE_LINE = re.compile("^\"INIT\"\)$")
-  KRN_LINE = re.compile("^\"KRN\",")
-  PKG_LINE = re.compile("^\"PKG\",")
-  END_LINE = re.compile("^\*\*END\*\*$")
-  DIC_LINE = re.compile("^\"\^DIC\"")
-  PRE_LINE = re.compile("^\"PRE\"\)$")
-  FIA_LINE = re.compile("^\"FIA\"")
-  IX_LINE = re.compile("^\"IX\"")
-  KEY_LINE = re.compile("^\"KEY\"")
-  KEYPTR_LINE = re.compile("^\"KEYPTR\"")
-  PGL_LINE = re.compile("^\"PGL\"")
-  FRV1_LINE = re.compile("^\"FRV1\"")
-  FRV1K_LINE = re.compile("^\"FRV1K\"")
-  REST_LINE = re.compile("^\"REST\"")
+  KIDS_LINE = re.compile(r"^\*\*KIDS\*\*")
+  INSTALL_NAME_LINE = re.compile(r"^\*\*INSTALL NAME\*\*$")
+  DATA_LINE = re.compile(r"^\"DATA\"")
+  DATA_DICTIONARY_LINE = re.compile(r"^\"\^DD\",")
+  SEC_LINE = re.compile(r"^\"SEC\",")
+  UP_LINE = re.compile(r"^\"UP\",")
+  QUES_LINE = re.compile(r"^\"QUES\",\".*\",.*\)$")
+  TEMP_LINE = re.compile(r"^\"TEMP\",")
+  MBREQ_LINE = re.compile(r"\"MBREQ\"")
+  ORD_LINE = re.compile(r"^\"ORD\",") # option, RPC, templates etc
+  ROUTINE_LINE = re.compile(r"^\"RTN\"")
+  BUILD_LINE = re.compile(r"^\"BLD\",[0-9]+")
+  VERSION_LINE = re.compile(r"^\"VER\"\)$")
+  PRE_INSTALL_ROUTINE_LINE = re.compile(r"^\"INI\"\)$")
+  POST_INSTALL_ROUTINE_LINE = re.compile(r"^\"INIT\"\)$")
+  KRN_LINE = re.compile(r"^\"KRN\",")
+  PKG_LINE = re.compile(r"^\"PKG\",")
+  END_LINE = re.compile(r"^\*\*END\*\*$")
+  DIC_LINE = re.compile(r"^\"\^DIC\"")
+  PRE_LINE = re.compile(r"^\"PRE\"\)$")
+  FIA_LINE = re.compile(r"^\"FIA\"")
+  IX_LINE = re.compile("r^\"IX\"")
+  KEY_LINE = re.compile(r"^\"KEY\"")
+  KEYPTR_LINE = re.compile(r"^\"KEYPTR\"")
+  PGL_LINE = re.compile(r"^\"PGL\"")
+  FRV1_LINE = re.compile(r"^\"FRV1\"")
+  FRV1K_LINE = re.compile(r"^\"FRV1K\"")
+  REST_LINE = re.compile(r"^\"REST\"")
 
   def __init__(self, outDir):
     self._outDir = outDir
@@ -535,7 +535,7 @@ class KIDSBuildParser(ISectionParser):
         else:
           section, parser = self.__isSectionLine__(curLine)
           if section == None: # could not find a valid section
-            logger.warn("Cannot parse %s" % lines[0])
+            logger.warning("Cannot parse %s" % lines[0])
             self.__resetCurrentSection__(section, parser, lines)
           else: # find a section
             if section != self._curSection:
@@ -705,7 +705,7 @@ class KIDSBuildParser(ISectionParser):
     self._kidsBuilds.append(self._curKidsBuild)
   def __onKIDSSectionStart__(self, section, lines, **kargs):
     line = lines[0].rstrip(" \r\n")
-    ret = re.search('^\*\*KIDS\*\*:(?P<name>.*)\^$', line)
+    ret = re.search(r'^\*\*KIDS\*\*:(?P<name>.*)\^$', line)
     if ret:
       self._installNameList = ret.group('name').rstrip(' ').split('^')
     else:

--- a/Scripts/MCompReposReadMeGenerator.py
+++ b/Scripts/MCompReposReadMeGenerator.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2013-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,10 +66,10 @@ class MCompReposReadMeGenerator(object):
       outputDir = os.path.join(self._outputDir, "Packages",
                                 packageName)
       if not os.path.exists(inputReadMePath):
-        logger.warn("No README.rst for Package %s" % packageName)
+        logger.warning("No README.rst for Package %s" % packageName)
         continue
       if not os.path.exists(outputDir):
-        logger.warn("Package %s does not exist in M Repository" % packageName)
+        logger.warning("Package %s does not exist in M Repository" % packageName)
         continue
       goldSection = self.__parseGoldSectionFromReadMe__(inputReadMePath)
       if goldSection:
@@ -123,7 +124,7 @@ class MCompReposReadMeGenerator(object):
     goldSection = None
     curModule = None
     while len(curLine) > 0:
-      if re.search('^\^+$', curLine):
+      if re.search(r'^\^+$', curLine):
         curModule = prevLine.strip(' \r\n')
         logger.debug("current module is %s" % curModule)
       elif curLine.startswith('.. table::'):

--- a/Scripts/PatchInfoParser.py
+++ b/Scripts/PatchInfoParser.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel: Python 3.12 support
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -155,7 +156,7 @@ class PatchInfoParser(object):
   SUBJECT_PART_START_REGEX = re.compile("^Subject:(?P<subj>.*)")
   ASSOCIATED_PATCH_START_REGEX = re.compile("^Associated patches: ")
   ASSOCIATED_PATCH_START_INDEX = 20
-  ASSOCIATED_PATCH_SECTION_REGEX = re.compile("^ {%d,%d}\(v\)" %
+  ASSOCIATED_PATCH_SECTION_REGEX = re.compile(r"^ {%d,%d}\(v\)" %
                                               (ASSOCIATED_PATCH_START_INDEX,
                                                ASSOCIATED_PATCH_START_INDEX))
   DESCRIPTION_REGEX = re.compile("^ *Description:")

--- a/Scripts/PatchOrderGenerator.py
+++ b/Scripts/PatchOrderGenerator.py
@@ -9,6 +9,7 @@
 #
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -254,17 +255,17 @@ class PatchOrderGenerator(object):
           logger.error("Duplicated KIDS build file %s" % kidsFile)
       for installName in installNameList:
         if installName in self._kidsInstallNameDict:
-          logger.warn("%s is already in the dict %s" % (installName, kidsFile))
+          logger.warning("%s is already in the dict %s" % (installName, kidsFile))
         logger.debug("Added installName %s, file %s" % (installName, kidsFile))
         self._kidsInstallNameDict[installName] = os.path.normpath(kidsFile)
         """ handle KIDS sha1 file Path """
         if sha1Path:
           if installName in self._kidsInstallNameSha1Dict:
-            logger.warn("%s is already in the dict %s" % (installName, sha1Path))
+            logger.warning("%s is already in the dict %s" % (installName, sha1Path))
           self._kidsInstallNameSha1Dict[installName] = sha1Path
         """ update kids dependency """
         if installName in self._kidsDepBuildDict:
-          logger.warn("%s already has the dep map %s" %
+          logger.warning("%s already has the dep map %s" %
                       (installName, self._kidsDepBuildDict[installName]))
         if kidsBuilds:
           for kidsBuild in kidsBuilds:
@@ -291,11 +292,11 @@ class PatchOrderGenerator(object):
       """ only add to list for info that is related to a Patch"""
       installName = patchInfo.installName
       if installName not in self._kidsInstallNameDict:
-        logger.warn("no KIDS file related to %s (%s)" % (installName, kidsInfoFile))
+        logger.warning("no KIDS file related to %s (%s)" % (installName, kidsInfoFile))
         if installName in self._missKidsBuildDict:
-          logger.warn("duplicated kids install name")
+          logger.warning("duplicated kids install name")
           if kidsInfoFile != self._missKidsBuildDict[installName].kidsInfoPath:
-            logger.warn("duplicated kids info file name %s" % kidsInfoFile)
+            logger.warning("duplicated kids info file name %s" % kidsInfoFile)
           continue
         self._missKidsBuildDict[installName] = patchInfo
         continue
@@ -307,7 +308,7 @@ class PatchOrderGenerator(object):
         patchInfo.kidsSha1Path = sha1Path
         patchInfo.kidsSha1 = readSha1SumFromSha1File(sha1Path)
       if installName in self._patchInfoDict:
-        logger.warn("duplicated installName %s, %s, %s" %
+        logger.warning("duplicated installName %s, %s, %s" %
                      (installName, self._patchInfoDict[installName],
                      kidsInfoFile))
       """ merge the dependency if needed, also
@@ -548,7 +549,7 @@ class PatchOrderGenerator(object):
       if installName not in self._patchInfoDict:
         if (installName not in self._informationalKidsSet and
             installName not in self._kidsInstallNameDict):
-          logger.warn("No KIDS file found for %s" % str(patchOrder))
+          logger.warning("No KIDS file found for %s" % str(patchOrder))
         continue
       patchInfo = self._patchInfoDict[installName]
       patchInfo.verifiedDate = patchOrder[2]

--- a/Scripts/PatchSequenceApply.py
+++ b/Scripts/PatchSequenceApply.py
@@ -8,6 +8,7 @@
 #
 #---------------------------------------------------------------------------
 # Copyright 2011-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -372,7 +373,7 @@ class PatchSequenceApply(object):
         itemIndex = self.indexInPatchList(item, patchList)
         patchIndex = self.indexInPatchList(patchInfo.installName, patchList)
         if itemIndex >= patchIndex:
-          logger.warn("%s is out of order with %s" % (item, patchInfo))
+          logger.warning("%s is out of order with %s" % (item, patchInfo))
           return False
         else:
           continue
@@ -384,7 +385,7 @@ class PatchSequenceApply(object):
       if self._vistaPatchInfo.isInstallCompleted(installStatus):
         continue
       elif item in patchInfo.optionalDepSet:
-        logger.warn("Patch specified in KIDS info file %s is not installed for %s" %
+        logger.warning("Patch specified in KIDS info file %s is not installed for %s" %
                     (item, patchInfo.installName))
         continue
       else:

--- a/Scripts/VistAGlobalImport.py
+++ b/Scripts/VistAGlobalImport.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +36,7 @@ class VistAGlobalImport(object):
   def __setupDeviceCache__(self, connection, nativeFile):
     connection.expect("Device:")
     connection.send("%s\r" % nativeFile)
-    connection.expect("Parameters\?")
+    connection.expect(r"Parameters\?")
     connection.send("\r")
     connection.expect("Input option: ")
     connection.send("A\r")

--- a/Scripts/VistAMenuUtil.py
+++ b/Scripts/VistAMenuUtil.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2013 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +56,7 @@ class VistAMenuUtil(object):
     connection = vistAClient.getConnection()
     connection.expect("Select Systems Manager Menu ")
     connection.send("\r")
-    connection.expect("Do you really want to halt\?")
+    connection.expect(r"Do you really want to halt\?")
     connection.send("\r")
     vistAClient.waitForPrompt()
     connection.send("\r")
@@ -78,11 +79,11 @@ class VistAMenuUtil(object):
     connection = vistAClient.getConnection()
     self.gotoProgrammerMenu(vistAClient)
     connection.send("KIDS\r")
-    connection.expect("Select Kernel Installation \& Distribution System ")
+    connection.expect(r"Select Kernel Installation \& Distribution System ")
 
   def exitKidsMainMenu(self, vistAClient):
     connection = vistAClient.getConnection()
-    connection.expect("Select Kernel Installation \& Distribution System")
+    connection.expect(r"Select Kernel Installation \& Distribution System")
     connection.send("\r")
     self.exitProgrammerMenu(vistAClient)
 

--- a/Scripts/VistAPackageInfoFetcher.py
+++ b/Scripts/VistAPackageInfoFetcher.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,7 +96,7 @@ class VistAPackageInfoFetcher(object):
     connection.expect("Select PACKAGE NAME:")
     connection.send("%s\r" % packageName)
     while True:
-      index  = connection.expect(["Select VERSION: [0-9.VvTtPp]+\/\/",
+      index  = connection.expect([r"Select VERSION: [0-9.VvTtPp]+\/\/",
                                   "Select VERSION: ",
                                   "Select Utilities ",
                                   "CHOOSE [0-9]+-[0-9]+"])
@@ -119,7 +120,7 @@ class VistAPackageInfoFetcher(object):
             have a version information (old system)
         """
         while True:
-          idx = connection.expect(["Do you want to see the Descriptions\?",
+          idx = connection.expect([r"Do you want to see the Descriptions\?",
                                     "CHOOSE [0-9]+-[0-9]+",
                                     "Select VERSION: ",
                                     "DEVICE:"])
@@ -215,11 +216,11 @@ class VistAPackageInfoFetcher(object):
     connection.send("17\r")
     connection.expect("THEN PRINT FIELD: ")
     connection.send("\r")
-    connection.expect("Heading \(S/C\): INSTALL SEARCH// ")
+    connection.expect(r"Heading \(S/C\): INSTALL SEARCH// ")
     connection.send("\r") # use default heading
     connection.expect("DEVICE:")
     connection.send(";132;99999\r")
-    connection.expect("[0-9]+ MATCH(ES)? FOUND\.")
+    connection.expect(r"[0-9]+ MATCH(ES)? FOUND\.")
     result = connection.lastconnection.split("\r\n")
     output = []
     resultStart = False

--- a/Scripts/VistARoutineExport.py
+++ b/Scripts/VistARoutineExport.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel: Python 3.12 support
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +28,7 @@ from LoggerManager import getTempLogFile
 
 class VistARoutineExport(object):
   """ regular expression constants """
-  REGEX_ROUTINES = "Routine(\(s\))?: "
+  REGEX_ROUTINES = r"Routine(\(s\))?: "
   def __init__(self):
     pass
   def __setupOutputInfoCache__(self, connection, outputFileName):
@@ -37,9 +38,9 @@ class VistARoutineExport(object):
     nativeName = os.path.normpath(outputFileName)
     connection.send("%s\r" % nativeName)
     """ this could be system dependent format """
-    selectionList = ["Parameters\? \"WNS\" =>",
+    selectionList = [r"Parameters\? \"WNS\" =>",
                      "Yes =>", # for prompt "file exists, do you want to overwrite it"
-                     "Printer Format\? No =>"]
+                     r"Printer Format\? No =>"]
     while True:
       index = connection.expect(selectionList)
       connection.send("\r")

--- a/Scripts/VistARoutineImport.py
+++ b/Scripts/VistARoutineImport.py
@@ -1,6 +1,6 @@
-
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel: Python 3.12 support
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ class VistARoutineImport(object):
   def __importRoutineCache__(self, connection, routineImportFile):
     connection.expect("Device: ")
     connection.send("%s\r" % routineImportFile)
-    connection.expect("Parameters\? ")
+    connection.expect(r"Parameters\? ")
     connection.send("\r")
     while True:
-      index = connection.expect(["Override and use this File with %RI\? No =>",
+      index = connection.expect([r"Override and use this File with %RI\? No =>",
                                  "Please enter a number from the above list:",
                                  "Routine Input Option:",
                                 ])
@@ -43,16 +43,16 @@ class VistARoutineImport(object):
       else:
         connection.send("All\r")
         break
-    connection.expect("shall it replace the one on file\? No =>")
+    connection.expect(r"shall it replace the one on file\? No =>")
     connection.send("YES\r")
-    connection.expect("Recompile\? Yes =>")
+    connection.expect(r"Recompile\? Yes =>")
     connection.send("\r")
-    connection.expect("Display Syntax Errors\? Yes =>")
+    connection.expect(r"Display Syntax Errors\? Yes =>")
     connection.send("\r")
 
   def __importRoutineGTM__(self, connection, routineImportFile,
                            routineOutputDir):
-    connection.expect("Formfeed delimited <No>\? ")
+    connection.expect(r"Formfeed delimited <No>\? ")
     connection.send("No\r")
     connection.expect("Input device: <terminal>: ")
     connection.send("%s\r" % routineImportFile)

--- a/Scripts/VistATaskmanUtil.py
+++ b/Scripts/VistATaskmanUtil.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2013 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -147,7 +148,7 @@ class VistATaskmanUtil(object):
     menuUtil = VistAMenuUtil(duz=1)
     menuUtil.gotoTaskmanMgrUtilMenu(vistAClient)
     connection.send("Place Taskman in a WAIT State\r")
-    connection.expect("Should active submanagers shut down after finishing their current tasks\? ")
+    connection.expect(r"Should active submanagers shut down after finishing their current tasks\? ")
     if shutdownSubMgrs:
       connection.send("YES\r")
     else:
@@ -173,7 +174,7 @@ class VistATaskmanUtil(object):
   def stopMailManBackgroundFiler(self, vistAClient):
     connection = vistAClient.getConnection()
     connection.send("D STOP^XMKPL\n")
-    connection.expect("Are you sure you want the Background Filers to stop delivering mail\? ")
+    connection.expect(r"Are you sure you want the Background Filers to stop delivering mail\? ")
     connection.send("YES\r")
     vistAClient.waitForPrompt()
     logger.info("Wait 30 seconds for Mailman background filer to stop")
@@ -224,7 +225,7 @@ class VistATaskmanUtil(object):
     connection.expect("Checking the Status List:")
     statusString = connection.lastconnection.strip(' \r\n').split('\r\n')[0]
     logger.debug("Status String is %s" % statusString)
-    connection.expect("Node        weight  status      time       \$J")
+    connection.expect(r"Node        weight  status      time       \$J")
     connection.expect("Checking the Schedule List:")
     detailedStatus = connection.lastconnection.strip(' \r\n')
     logger.debug("Detailed Status String is %s" % detailedStatus)

--- a/Scripts/VistATestClient.py
+++ b/Scripts/VistATestClient.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2012-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -175,7 +176,7 @@ class VistATestClientCacheWindows(VistATestClientCache, ConnectWinCache):
 
 """ Implementation of Cache on Linux system """
 class VistATestClientCacheLinux(VistATestClientCache, ConnectLinuxCache):
-  DEFAULT_CACHE_CMD = "ccontrol session"
+  DEFAULT_CACHE_CMD = "irissession"
   def __init__(self, namespace):
     assert namespace, "Must provide a namespace"
     prompt = namespace + CACHE_PROMPT_END
@@ -196,7 +197,7 @@ class VistATestClientCacheLinux(VistATestClientCache, ConnectLinuxCache):
 
 """ constants for default value """
 DEFAULT_NAMESPACE = "VISTA"
-DEFAULT_INSTANCE = "CACHE"
+DEFAULT_INSTANCE = "IRIS"
 
 """ generate argument parse for VistATestClientFactory """
 def createTestClientArgParser():

--- a/Utilities/Dox/CMakeLists.txt
+++ b/Utilities/Dox/CMakeLists.txt
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2011 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Increase timeout for CALLGRAPH job.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,7 +116,7 @@ if (GENERATE_DOX OR GENERATE_VIVIAN)
 
       # Creates the command that will be called for the Test
       add_test(CALLERGRAPH_${package_file_name} ${CMAKE_COMMAND} -P ${SCRIPT_OUTPUT_DIR}/${package_file_name}.cmake)
-      set_tests_properties(CALLERGRAPH_${package_file_name} PROPERTIES TIMEOUT 5000)
+      set_tests_properties(CALLERGRAPH_${package_file_name} PROPERTIES TIMEOUT 7200)
     endif()
   endforeach()
 endif()

--- a/Utilities/Dox/MRoutineAnalyzer.cmake.in
+++ b/Utilities/Dox/MRoutineAnalyzer.cmake.in
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2011 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +23,7 @@ message(STATUS "Filema database information...")
 set(ENV{VistA-FOIA} @DOCUMENT_VISTA_M_DIR@)
 
 # Download the 'fileman_json' branch of the 'rgivistatools' repo
-set(git_repository https://github.com/jasonli2000/rgivistatools)
+set(git_repository https://github.com/WorldVistA/rgivistatools)
 set(git_tag "fileman_json")
 set(src_name "@CMAKE_BINARY_DIR@/rgivistatools")
 
@@ -45,15 +46,6 @@ execute_process(
   )
 if(error_code)
   message(FATAL_ERROR "Failed to checkout tag: '${git_tag}' (${error_code})")
-endif()
-
-execute_process(
-  COMMAND "@GIT_EXECUTABLE@" pull
-  WORKING_DIRECTORY ${src_name}
-  RESULT_VARIABLE error_code
-  )
-if(error_code)
-  message(FATAL_ERROR "Failed to update repository: '${git_tag}' (${error_code})")
 endif()
 
 set(src_dir "${src_name}/MParseAnalyze/src")

--- a/Utilities/Dox/PythonScripts/DataDictionaryParser.py
+++ b/Utilities/Dox/PythonScripts/DataDictionaryParser.py
@@ -5,6 +5,7 @@
 #---------------------------------------------------------------------------
 # Copyright 2012 The Open Source Electronic Health Record Agent
 # Copyright 2021 Sam Habiel
+# Copyright 2024 Sam Habiel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -197,7 +198,7 @@ class FileManFieldSectionParser(IDDSectionParser):
         else:
             # handle three cases, 1. no location info 2. no type info 3. Both
             if restOfLine.find(";") != -1: # missing type info
-                logger.warn("Missing Type information [%s]" % line)
+                logger.warning("Missing Type information [%s]" % line)
                 result = NAME_LOC_REGEX.search(restOfLine)
                 if result:
                     fName = result.group('Name').strip()
@@ -211,7 +212,7 @@ class FileManFieldSectionParser(IDDSectionParser):
                     fName = result.group('Name').strip()
                     fType = result.group('Type').strip()
                 else:
-                    logger.warn("Guessing Name: %s at line [%s]" % (restOfLine.strip(), line))
+                    logger.warning("Guessing Name: %s at line [%s]" % (restOfLine.strip(), line))
         stripedType = ""
         if fType:
             stripedType = self.__stripFieldAttributes__(fType)

--- a/Utilities/Dox/PythonScripts/FileManDataToHtml.py
+++ b/Utilities/Dox/PythonScripts/FileManDataToHtml.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2014 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +17,7 @@
 from future import standard_library
 standard_library.install_aliases()
 
-import cgi
+import html
 import json
 import os
 import re
@@ -55,7 +56,7 @@ SCRIPTS_DIR = os.path.normpath(os.path.join(FILE_DIR, "../../../Scripts"))
 if SCRIPTS_DIR not in sys.path:
   sys.path.append(SCRIPTS_DIR)
 
-ZZSERVER_SUBMENU_REGEX = re.compile("19\^[9]+")
+ZZSERVER_SUBMENU_REGEX = re.compile(r"19\^[9]+")
 
 
 class OSEHRAEncoder(JSONEncoder):
@@ -616,7 +617,7 @@ class FileManDataToHtml(object):
       outputDataListTableHeader(output, tName, columnNames, searchColumnNames)
       output.write("<body id=\"dt_example\">")
       output.write("<a class=\"brand\" href=\"%s\" style=\"height:50px; padding: 0px;\"> \
-                  <img src=\"https://osehra.org/sites/default/files/vivian.png\" width=\"137\" height=\"50\"/></a>" % VIV_URL)
+                  <img src=\"/vivian/vivian.png\" width=\"137\" height=\"50\"/></a>" % VIV_URL)
       output.write("""<div id="container" style="width:80%">""")
       if pkgName == "All":
         pkgLinkName = pkgName
@@ -690,7 +691,7 @@ class FileManDataToHtml(object):
                                      hideColumnNames=[""] )
       output.write("<body id=\"dt_example\">")
       output.write("<a class=\"brand\" href=\"%s\" style=\"height:50px; padding: 0px;\"> \
-                  <img src=\"https://osehra.org/sites/default/files/vivian.png\" width=\"137\" height=\"50\"/></a>" % VIV_URL)
+                  <img src=\"/vivian/vivian.png\" width=\"137\" height=\"50\"/></a>" % VIV_URL)
       output.write("""<div id="container" style="width:80%">""")
       output.write("<h1>File %s(%s) Data List</h1>" % (tName, fileNo))
       outputDataTableHeader(output, fieldNamesList, tName)
@@ -754,7 +755,7 @@ class FileManDataToHtml(object):
         outputDataRecordTableHeader(output, tName)
         output.write("<body id=\"dt_example\">")
         output.write("<a class=\"brand\" href=\"%s\" style=\"height:50px; padding: 0px;\"> \
-                    <img src=\"https://osehra.org/sites/default/files/vivian.png\" width=\"137\" height=\"50\"/></a>" % VIV_URL)
+                    <img src=\"/vivian/vivian.png\" width=\"137\" height=\"50\"/></a>" % VIV_URL)
         output.write("""<div id="container" style="width:80%">""")
         output.write ("<h1>%s (%s) &nbsp;&nbsp;  %s (%s)</h1>\n" % (name, ien,
                                                                     fileManData.name,
@@ -829,7 +830,7 @@ class FileManDataToHtml(object):
           fieldType == FileManField.FIELD_TYPE_FREE_TEXT and "FILE COMMENT" == name):
       if isinstance(value, list):
         value = "\n".join(value)
-      value = "<pre>\n" + cgi.escape(value) + "\n</pre>\n"
+      value = "<pre>\n" + html.escape(value) + "\n</pre>\n"
 
     if isRoot:
       retval += "<tr>\n"

--- a/Utilities/Dox/PythonScripts/FileManDbCallParser.py
+++ b/Utilities/Dox/PythonScripts/FileManDbCallParser.py
@@ -4,6 +4,7 @@
 # the FileMan db call dependencies among packages.
 #---------------------------------------------------------------------------
 # Copyright 2013 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +58,7 @@ class FileManDbCallParser(object):
                     rtnName = rtn['name']
                     routine = self._crossRef.getRoutineByName(rtnName)
                     if not routine:
-                        logger.warn("Cannot find routine [%s]" % rtnName)
+                        logger.warning("Cannot find routine [%s]" % rtnName)
                         continue
                     fileManGlobals = rtn['Globals']
                     self._addFileManGlobals(routine, fileManGlobals)

--- a/Utilities/Dox/PythonScripts/FileManGlobalDataParser.py
+++ b/Utilities/Dox/PythonScripts/FileManGlobalDataParser.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2014 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,11 +84,11 @@ INSTALL_RENAME_DICT = {"Kernel Public Domain" : "Kernel",
                           }
 
 
-REGEX_RTN_CODE = re.compile("( ?[DQI] |[:',])(\$\$)?(?P<tag>"
-                         "([A-Z0-9][A-Z0-9]*)?)\^(?P<rtn>[A-Z%][A-Z0-9]+)")
-ZWR_FILE_REGEX = re.compile("(?P<fileNo>^[0-9.]+)(-[1-9])?\+(?P<des>.*)\.zwr$")
-PACKAGE_CHANGE_REGEX = re.compile("\*+")
-PACKAGE_NAME_VAL_REGEX = re.compile("(?P<packageName>[A-Z./ \&\-\']+) (?P<packageVal>[.0-9]+)")
+REGEX_RTN_CODE = re.compile(r"( ?[DQI] |[:',])(\$\$)?(?P<tag>"
+                         r"([A-Z0-9][A-Z0-9]*)?)\^(?P<rtn>[A-Z%][A-Z0-9]+)")
+ZWR_FILE_REGEX = re.compile(r"(?P<fileNo>^[0-9.]+)(-[1-9])?\+(?P<des>.*)\.zwr$")
+PACKAGE_CHANGE_REGEX = re.compile(r"\*+")
+PACKAGE_NAME_VAL_REGEX = re.compile(r"(?P<packageName>[A-Z./ \&\-\']+) (?P<packageVal>[.0-9]+)")
 
 def getMumpsRoutine(mumpsCode):
   """
@@ -453,7 +454,7 @@ class FileManGlobalDataParser(object):
           elif '12' in protocolEntry.fields: # check the packge it belongs
             pass
           else:
-            logger.warn("Cannot find a package for HL7: %s" % entryName)
+            logger.warning("Cannot find a package for HL7: %s" % entryName)
           for field in ('771', '772'):
             if field not in protocolEntry.fields:
               continue
@@ -512,7 +513,7 @@ class FileManGlobalDataParser(object):
       package = INSTALL_PACKAGE_FIX[installEntryName]
     # If it cannot match a package by namespace, capture the name via Regular Expression
     if package is None:
-      pkgMatch = re.match("[A-Z./ \&\-\']+", installEntryName)
+      pkgMatch = re.match(r"[A-Z./ \&\-\']+", installEntryName)
       if pkgMatch:
         # if a match is found, switch to title case and remove extra spaces
         targetName = pkgMatch.group(0).title().strip()
@@ -715,7 +716,7 @@ class FileManGlobalDataParser(object):
           fileNo = self.getFileNoByGlobalLocation(vpInfo[1])
           ien = vpInfo[0]
           if not fileNo:
-            logger.warn("Could not find File for %s" % value)
+            logger.warning("Could not find File for %s" % value)
             fieldDetail = 'Global Root: %s, IEN: %s' % (vpInfo[1], ien)
       if fileNo and ien:
         fieldDetail = '^'.join((fileNo, ien))
@@ -736,7 +737,7 @@ class FileManGlobalDataParser(object):
         if outDt:
           fieldDetail = outDt
         else:
-          logger.warn("Could not parse Date/Time: %s" % value)
+          logger.warning("Could not parse Date/Time: %s" % value)
     elif fieldAttr.getName().upper().startswith("TIMESTAMP"): # timestamp field
       if value.find(',') >=0:
         fieldDetail = horologToDateTime(value)

--- a/Utilities/Dox/PythonScripts/FileManSchemaParser.py
+++ b/Utilities/Dox/PythonScripts/FileManSchemaParser.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2014 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -215,11 +216,11 @@ class FileManSchemaParser(object):
 
   def _parseSchemaField(self, fieldNo, rootNode, fileSchema):
     if '0' not in rootNode:
-      logger.warn('%s does not have a 0 subscript' % rootNode)
+      logger.warning('%s does not have a 0 subscript' % rootNode)
       return None
     zeroFields = rootNode["0"].value
     if not zeroFields:
-      logger.warn("No value: %s for %s" % (zeroFields, rootNode['0']))
+      logger.warning("No value: %s for %s" % (zeroFields, rootNode['0']))
       return None
     zeroFields = zeroFields.split('^')
     if len(zeroFields) < 2:
@@ -295,7 +296,7 @@ class FileManSchemaParser(object):
         self._noPointedToFiles[fileGlobalRoot] = Global(fileGlobalRoot)
         logger.info("@TODO, set the file number for %s" % fileGlobalRoot)
       else:
-        logger.warn("No pointed to file set for file:%s: field:%r 0-index:%s" %
+        logger.warning("No pointed to file set for file:%s: field:%r 0-index:%s" %
                      (fileSchema.getFileNo(), fileField, zeroFields))
     elif fileField.getType() == FileManField.FIELD_TYPE_SUBFILE_POINTER:
       if subFile:
@@ -306,7 +307,7 @@ class FileManSchemaParser(object):
         fileSchema.addFileManSubFile(subFileSchema)
         fileField.setPointedToSubFile(subFileSchema)
       else:
-        logger.warn("No subfile is set for file:%s, field:%r 0-index:%s" %
+        logger.warning("No subfile is set for file:%s, field:%r 0-index:%s" %
                      (fileSchema.getFileNo(), fileField, zeroFields))
     elif fileField.getType() == FileManField.FIELD_TYPE_SET and not subFile and zeroFields[2]:
       setDict = dict([x.split(':') for x in zeroFields[2].rstrip(';').split(';')])

--- a/Utilities/Dox/PythonScripts/HTMLUtilityFunctions.py
+++ b/Utilities/Dox/PythonScripts/HTMLUtilityFunctions.py
@@ -1,5 +1,6 @@
 # ---------------------------------------------------------------------------
 # Copyright 2018 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Fix copyright notice.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@ FOOTER = """
 <br/>
 <br/>
 <br/>
-<div id="footer">&#xa9;2011-2018 Open Source Electronic Health Record Alliance<br />This work is licensed under a&nbsp;<a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a> <a href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a></div>
+<div id="footer">&#xa9;2011-2020 Open Source Electronic Health Record Alliance<br />&#xa9;2020-present WorldVistA<br />This work is licensed under a&nbsp;<a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a> <a href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a></div>
 </center>
 </body>
 </html>

--- a/Utilities/Dox/PythonScripts/ICRJsonToHtml.py
+++ b/Utilities/Dox/PythonScripts/ICRJsonToHtml.py
@@ -1,6 +1,7 @@
 # This module is parses ICR in JSON format and convert to html web page
 #---------------------------------------------------------------------------
 # Copyright 2011 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +22,7 @@ from future.utils import iteritems
 from past.utils import old_div
 import json
 import os.path
-import cgi
+import html
 import io
 import re
 
@@ -120,7 +121,7 @@ def convertJson(inputJsonFile, date, MRepositDir, patchRepositDir,
             for pkgName, outJson in iteritems(pkgJson):
                 _generateICRSummaryPageImpl(outJson, 'ICR List', pkgName, date,
                                             outDir, crossRef)
-            logger.warn('Total # entry in pkgJson is [%s]', len(pkgJson))
+            logger.warning('Total # entry in pkgJson is [%s]', len(pkgJson))
             _generatePkgDepSummaryPage(inputJson, date, outDir, crossRef)
 
         # TODO: Log failures
@@ -145,7 +146,7 @@ def _getICRIndividualHtmlFileLinkByIen(value, icrEntry, **kargs):
         if not line:  # Empty string
           ienDescription += '\n'
         else:
-          ienDescription += ' ' + cgi.escape(line).replace('"', r"&quot;").replace("'", r"&quot;")
+          ienDescription += ' ' + html.escape(line).replace('"', r"&quot;").replace("'", r"&quot;")
     return '<a title=\"%s\" href=\"%s\">%s</a>' % (ienDescription, '%s/ICR/ICR-%s.html' % 	 (FILES_URL, ien), value)
 
 
@@ -156,7 +157,7 @@ def _getGeneralDescription(value, icrEntry, **kargs):
         if not line:  # Empty string
           description += '\n'
         else:
-          description += '<br>' + cgi.escape(line).replace('"', r"&quot;").replace("'", r"&quot;")
+          description += '<br>' + html.escape(line).replace('"', r"&quot;").replace("'", r"&quot;")
     return description
 
 
@@ -455,7 +456,7 @@ def _generateICRIndividualPagePDF(icrJson, date, pdfOutDir):
     else:
         # TODO: PDF will not be included in a package bundle and will not be
         #       accessible from the Dox pages
-        logger.warn("Could not find package for: ICR %s" % ien)
+        logger.warning("Could not find package for: ICR %s" % ien)
     pdfFile = os.path.join(pdfOutDir, 'ICR-' + ien + '.pdf')
 
     # Setup the pdf document
@@ -536,9 +537,9 @@ def _icrDataEntryToPDF(pdf, icrJson, doc):
                 description.append(Paragraph('GENERAL DESCRIPTION', STYLES['Heading3']))
                 if isinstance(value, list):
                     for line in value:
-                        description.append(Paragraph(cgi.escape(line), STYLES['Normal']))
+                        description.append(Paragraph(html.escape(line), STYLES['Normal']))
                 else:
-                    description.append(Paragraph(cgi.escape(value), STYLES['Normal']))
+                    description.append(Paragraph(html.escape(value), STYLES['Normal']))
                 if description:
                     pdf.append(KeepTogether(description))
                 continue
@@ -703,7 +704,7 @@ def _writeTableOfValue(output, field, value, crossRef):
             # ICR-5317
             if "Type:" in variables:
                 # <variableName> Type: <variable type> <description>
-                ICR_5317_REGEX = re.compile("^(?P<varName>[A-Z]+)\s+Type:\s+(?P<varType>[A-Za-z]+)\s*(?P<description>.*)")
+                ICR_5317_REGEX = re.compile(r"^(?P<varName>[A-Z]+)\s+Type:\s+(?P<varType>[A-Za-z]+)\s*(?P<description>.*)")
                 ret = ICR_5317_REGEX.search(variables)
                 entry[val][0]['VARIABLES'] = ret.group('varName')
                 entry[val][0]['TYPE'] = ret.group('varType')
@@ -764,7 +765,7 @@ def _convertIndividualFieldValue(field, icrEntry, value, crossRef):
     if isWordProcessingField(field):
         if isinstance(value, list):
             value = "\n".join(value)
-        value = '<pre>\n' + cgi.escape(value) + '\n</pre>\n'
+        value = '<pre>\n' + html.escape(value) + '\n</pre>\n'
         return value
     if field in FIELD_CONVERT_MAP:
         if isinstance(value, list):
@@ -780,7 +781,7 @@ def _convertIndividualFieldValuePDF(field, value, writeField=False,
         if isinstance(value, list):
             cell = []
             for item in value:
-                text = cgi.escape(item)
+                text = html.escape(item)
                 if writeField:
                   text = "%s : %s" % (field, text)
                 # TODO: "Field:" should not be styled as 'Code'
@@ -790,7 +791,7 @@ def _convertIndividualFieldValuePDF(field, value, writeField=False,
             else:
                 return cell
         else:
-            text = cgi.escape(value)
+            text = html.escape(value)
             if writeField:
               text = "%s : %s" % (field, text)
             # TODO: "Field:" should not be styled as 'Code'

--- a/Utilities/Dox/PythonScripts/ICRSchema.py
+++ b/Utilities/Dox/PythonScripts/ICRSchema.py
@@ -1,6 +1,7 @@
 # This file defined the reverse engineered ICR fileman schema
 #---------------------------------------------------------------------------
 # Copyright 2018 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -152,7 +153,7 @@ DATE_TIME_FIELD = set([
 ])
 
 # regular  expression for fields
-INTEGRATION_REFERENCES_LIST = re.compile('^\s*INTEGRATION REFERENCES (LIST|List) *(.*)(([01]\d|2[0-3]):([0-5]\d)|24:00) *PAGE')
+INTEGRATION_REFERENCES_LIST = re.compile(r'^\s*INTEGRATION REFERENCES (LIST|List) *(.*)(([01]\d|2[0-3]):([0-5]\d)|24:00) *PAGE')
 
 
 """ SOME UTILITY FUNCTIONS  """
@@ -168,7 +169,7 @@ def isWordProcessingField(field):
 def getDate(icrFilename):
     with open(icrFilename, 'r') as ICRFile:
         for line in ICRFile:
-            line = line.rstrip("\r\n")
+            line = line.rstrip(r"\r\n")
             match = INTEGRATION_REFERENCES_LIST.match(line)
             if match:
                 return match.group(2).strip()

--- a/Utilities/Dox/PythonScripts/InitCrossReferenceGenerator.py
+++ b/Utilities/Dox/PythonScripts/InitCrossReferenceGenerator.py
@@ -1,5 +1,6 @@
 # ---------------------------------------------------------------------------
 # Copyright 2018 The Open Source Electronic Health Record Alliance
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,9 +33,9 @@ from ArgParserHelper import createArgParser as createInitialCrossRefGenArgParser
 from CrossReference import CrossReference, Routine, Package, Global, PlatformDependentGenericRoutine
 from LogManager import logger
 
-A_ROUTINE_EX = re.compile("^A[0-9][^ ]+$")
-ZWR_FILENO_REGEX = re.compile("(?P<fileNo>^[0-9.]+)(-1)?\+(?P<des>.*)\.zwr$")
-ZWR_NAMESPACE_REGEX = re.compile("(?P<namespace>^[^.]+)\.zwr$")
+A_ROUTINE_EX = re.compile(r"^A[0-9][^ ]+$")
+ZWR_FILENO_REGEX = re.compile(r"(?P<fileNo>^[0-9.]+)(-1)?\+(?P<des>.*)\.zwr$")
+ZWR_NAMESPACE_REGEX = re.compile(r"(?P<namespace>^[^.]+)\.zwr$")
 
 fileNoPackageMappingDict = {"18.02":"Web Services Client",
                    "18.12":"Web Services Client",
@@ -82,7 +83,7 @@ class InitCrossReferenceGenerator(object):
           currentPackage.setDocLink(getVDLHttpLinkByID(vdlId))
       else:
         if not currentPackage:
-          logger.warn("row is not under any package: %s" % row)
+          logger.warning("row is not under any package: %s" % row)
           continue
       if len(row['Prefixes']):
         currentPackage.addNamespace(row['Prefixes'])
@@ -181,7 +182,7 @@ class InitCrossReferenceGenerator(object):
         lineNo = lineNo + 1
       if not fileNo:
         if file not in skipFile:
-          logger.warn("Warning: No FileNo found for file %s" % file)
+          logger.warning("Warning: No FileNo found for file %s" % file)
         continue
       globalVar = Global(globalName, fileNo, globalDes,
                          allPackages.get(packageName))

--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -4,6 +4,7 @@
 # Visual Cross Reference Documentation (DOX) pages.
 #---------------------------------------------------------------------------
 # Copyright 2011-2019 The Open Source Electronic Health Record Alliance
+# Copyright 2014 Sam Habiel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -255,13 +256,13 @@ PC_LEGEND += """
   </div>
 """
 
-INDEX_HTML_PAGE_OSEHRA_IMAGE_PART = """
+INDEX_HTML_PAGE_WV_IMAGE_PART = """
 <br/>
 <left>
 <div class="content">
-<a href="https://www.osehra.org">
-<img src="https://www.osehra.org/profiles/drupal_commons/themes/commons_osehra_earth/logo.png"
-style="border-width:0" alt="OSEHRA" /></a>
+<a href="https://www.worldvista.org">
+<img src="https://opensourcevista.net/NancysVistAServer/WorldVistALogoSmall.jpg"
+style="border-width:0" alt="WorldVistA" /></a>
 </div>
 </left>
 <br/>
@@ -273,8 +274,8 @@ INDEX_HTML_PAGE_INTRODUCTION_PART = """
 Welcome to VistA Cross Reference Documentation Page.
 This documentation is generated with the results of XINDEX and
  FileMan Data Dictionary utility running against the VistA code base pulled
- from the <a href="https://code.osehra.org/gitweb?p=VistA-M.git;a=summary"/>
-repository</a>.
+ from the <a href="https://foia-vista.worldvista.org/DBA_VistA_FOIA_System_Files/">
+FOIA site</a>.
 This documentation provides direct dependency information among packages,
  among FileMan files,  between globals and routines,
  as well as direct call/caller graphs and source code for individual routine.
@@ -764,11 +765,11 @@ class WebPageGenerator(object):
     def generateIndexHtmlPage(self):
         outputFile = open(os.path.join(self._outDir, "index.html"), 'w')
         outputFile.write(COMMON_HEADER_PART)
-        outputFile.write("<title>OSEHRA VistA Code Documentation</title>")
+        outputFile.write("<title>Vivian VistA Code Documentation</title>")
         outputFile.write(GOOGLE_ANALYTICS_JS_CODE)
         outputFile.write(HEADER_END)
         outputFile.write(DEFAULT_BODY_PART)
-        outputFile.write(INDEX_HTML_PAGE_OSEHRA_IMAGE_PART)
+        outputFile.write(INDEX_HTML_PAGE_WV_IMAGE_PART)
         outputFile.write(INDEX_HTML_PAGE_HEADER)
         outputFile.write(TOP_INDEX_BAR_PART)
         outputFile.write(INDEX_HTML_PAGE_INTRODUCTION_PART)
@@ -2873,7 +2874,7 @@ class WebPageGenerator(object):
         if len(package.getDocLink()) > 0:
             outputFile.write("<div><p><h4 id=\"packageDocs\">VA documentation in the <a target='blank' href=\"%s\">VistA Documentation Library</a></p></div>" % package.getDocLink())
             if len(package.getDocMirrorLink()) > 0:
-                outputFile.write("&nbsp;or&nbsp;<a href=\"%s\">OSEHRA Mirror site</a></h4></div>\n" % package.getDocMirrorLink())
+                outputFile.write("&nbsp;or&nbsp;<a href=\"%s\">WorldVistA Mirror site</a></h4></div>\n" % package.getDocMirrorLink())
         else:
             outputFile.write("<div><p><h4><a href=\"https://www.va.gov/vdl/\">VA documentation in the VistA Documentation Library</a></h4></p></div>\n")
         writeSectionEnd(outputFile)

--- a/Utilities/Dox/PythonScripts/ZWRGlobalParser.py
+++ b/Utilities/Dox/PythonScripts/ZWRGlobalParser.py
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2012 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel. Python 3.12 changes.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -194,7 +195,7 @@ class DefaultZWRRootGenerator(object):
     if rootSub != self.rootSub: # not under the same root, ignore
       retNode = self.curRoot
       if self.glbLoc:
-        logger.warn("Different root, expected: %s, real: %s, ignore for now" %
+        logger.warning("Different root, expected: %s, real: %s, ignore for now" %
                       (self.rootSub, rootSub))
         self.curRoot = None
         return True
@@ -210,7 +211,7 @@ class DefaultZWRRootGenerator(object):
         else:
           return True
     if self.commonSubscript and subscripts[0:self.index] != self.commonSubscript:
-      logger.warn("Different subsript, expected: %s, real: %s, ignore for now" %
+      logger.warning("Different subsript, expected: %s, real: %s, ignore for now" %
                       (self.commonSubscript, subscripts[0:self.index]))
       retNode = self.curRoot
       self.curRoot = None

--- a/Utilities/Dox/XINDEXInstall.cmake.in
+++ b/Utilities/Dox/XINDEXInstall.cmake.in
@@ -1,5 +1,6 @@
 #---------------------------------------------------------------------------
 # Copyright 2018 The Open Source Electronic Health Record Agent
+# Copyright 2024 Sam Habiel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +20,10 @@ set(vendor_args "")
 SetVendorArgsConfig(vendor_args "@VENDOR_NAME@" "@VISTA_CACHE_NAMESPACE@"
                      "@VISTA_CACHE_INSTANCE@" "@VISTA_CACHE_USERNAME@"
                      "@VISTA_CACHE_PASSWORD@")
-set(XINDEX_PATCH_DIR "@CMAKE_CURRENT_SOURCE_DIR@/Patches")
-set(PATCH_INSTALL_SCRIPT "@VISTA_SOURCE_DIR@/Scripts/PatchSequenceApply.py")
-set(LOG_DIR "@DOCUMENT_VISTA_FILES_OUTPUT_DIR@")
-list(APPEND vendor_args -p "${XINDEX_PATCH_DIR}" -l "${LOG_DIR}" -i -n "all")
-execute_process(COMMAND "@PYTHON_EXECUTABLE@" "@VISTA_SOURCE_DIR@/Scripts/PatchSequenceApply.py" ${vendor_args}
+set(XINDEX_PATCH "@CMAKE_CURRENT_SOURCE_DIR@/Patches/XT-7p3-10001T4.KID")
+set(LOG_FILE "@DOCUMENT_VISTA_FILES_OUTPUT_DIR@/xindex_install.log")
+list(APPEND vendor_args -d 1 -bub IN -l "${LOG_FILE}" "${XINDEX_PATCH}")
+execute_process(COMMAND "@PYTHON_EXECUTABLE@" "@VISTA_SOURCE_DIR@/Scripts/DefaultKIDSBuildInstaller.py" ${vendor_args}
                 RESULT_VARIABLE retCode
                 OUTPUT_VARIABLE output)
 if(retCode)

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,7 +1,7 @@
-future==0.17.1
-Pillow==8.3.2
-reportlab==3.5.23
+future==1.0.0
+Pillow==10.4
+reportlab==3.6.13
 xlrd==1.2.0
-paramiko==2.10.1
 chardet==3.0.4
+paramiko==2.12.0
 configparser==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-future==0.17.1
-Pillow==8.3.2
-reportlab==3.5.23
+future==1.0.0
+Pillow==10.4
+reportlab==3.6.13
 xlrd==1.2.0
 chardet==3.0.4
 pexpect==4.7.0
-paramiko==2.10.1
+paramiko==2.12.0
 configparser==3.5.0


### PR DESCRIPTION
Thie commit updates Vivian to run on RHEL 8/Rocky Linux 8, sunsets Cache in favor of IRIS, and upgrades Python 3.6 -> 3.12.

- CMakeFiles
	- `CMakeLists.txt`: Upgrade mimimum version to a recently supported version
	- `Utilities/Dox/CMakeLists.txt`: Increase timeout to 7200 for CALLGRAPH as IB package takes very long to finish.
	- `Utilities/Dox/MRoutineAnalyzer.cmake.in`: Move repo from jasonli2000 to WorldVistA to prevent future loss; don't clone/fetch repo if it is already exists
	- `Utilities/Dox/XINDEXInstall.cmake.in`: Change the install to use `DefaultKIDSBuildInstaller.py` rather than `PatchSequenceApply.py`; the latter starts taskman, which eats up the license spots we need for extraction; and we don't need taskman for this install.
- Python 3.6 -> 3.12 changes:
	- Regular expression strings need to be sent as "raw" strings. (https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python)
	- `logger.warn` -> `logger.warning` (warn deprecated).
	- `cgi` package no longer exists. Must use `html` instead.
- Other Python changes:
	- `ccontrol session` -> `irissession`
	- `CACHE` -> `IRIS`
	- `Utilities/Dox/PythonScripts/FileManDataToHtml.py`: Fix links to `vivian.png` that were broken post-OSEHRA demise
	- `Utilities/Dox/PythonScripts/HTMLUtilityFunctions.py`: Update copyright to include WorldVistA
	- `Utilities/Dox/PythonScripts/WebPageGenerator.py`: Change links from OSEHRA to WorldVistA
- ZGO changes:
	- IRIS has a different $ZV than Cache
	- Globals from `Fetch^%SYS.GD` are now in `^IRIS.TempJ`, not `^CacheTempJ`
	- IRIS firmly obeys license data, unlike Cache which didn't actually return useful data, so logic for ZGO now handles it properly.
	- Fix $SY check for GT.M/YDB to be better (no more +$SY, which can result in NUMOVERFLOW error).
- `requirements*.txt`: Upgrade versions of libraries so that they would work with Python 3.12.
- Documentation update